### PR TITLE
Add initial support for retrieving the current pose

### DIFF
--- a/src/dominh/__init__.py
+++ b/src/dominh/__init__.py
@@ -383,6 +383,11 @@ class MotionGroup(object):
         return self._id
 
     @property
+    def curpos(self) -> Position_t:
+        """Returns the current Cartesian pose"""
+        return group.get_current_pose(self._conx, group=self._id)
+
+    @property
     def robot_id(self) -> str:
         """Returns the robot model ID for which this group is configured"""
         return group.get_robot_id(self._conx, group=self._id)

--- a/src/dominh/group.py
+++ b/src/dominh/group.py
@@ -91,7 +91,10 @@ def get_payload(conx, idx: int, grp: int = 1) -> Plst_Grp_t:
 
 
 def get_current_pose(conx, group: int = 1, restore_grp: bool = False) -> Position_t:
-    """Retrieve the current Cartesian pose for group 'group'.
+    """Return the position of the TCP relative to the current user frame.
+
+    x, y, and z are in millimeters.
+    w, p, and r are in degrees.
 
     NOTE: this method can be slow if 'restore_grp' is True, as in that case
     multiple KCL commands have to be used.

--- a/src/dominh/types.py
+++ b/src/dominh/types.py
@@ -15,56 +15,47 @@
 # author: G.A. vd. Hoorn
 
 
-from collections import namedtuple
+from dataclasses import dataclass
 
 
-Plst_Grp_t = namedtuple(
-    'Plst_Grp_t',
-    [
-        'comment',
-        'payload',
-        'payload_x',
-        'payload_y',
-        'payload_z',
-        'payload_ix',
-        'payload_iy',
-        'payload_iz',
-    ],
-)
+@dataclass
+class Plst_Grp_t:
+    comment: str
+    payload: float
+    payload_x: float
+    payload_y: float
+    payload_z: float
+    payload_ix: float
+    payload_iy: float
+    payload_iz: float
 
-Config_t = namedtuple(
-    'Config_t',
-    [
-        'flip',
-        'up',
-        'top',
-        'turn_no1',
-        'turn_no2',
-        'turn_no3',
-    ],
-)
 
-Position_t = namedtuple(
-    'Position_t',
-    [
-        'config',
-        'x',
-        'y',
-        'z',
-        'w',
-        'p',
-        'r',
-    ],
-)
+@dataclass
+class Config_t:
+    flip: bool
+    up: bool
+    top: bool
+    turn_no1: int
+    turn_no2: int
+    turn_no3: int
 
-JointPos_t = namedtuple(
-    'JointPos_t',
-    [
-        'j1',
-        'j2',
-        'j3',
-        'j4',
-        'j5',
-        'j6',
-    ],
-)
+
+@dataclass
+class Position_t:
+    config: Config_t
+    x: float
+    y: float
+    z: float
+    w: float
+    p: float
+    r: float
+
+
+@dataclass
+class JointPos_t:
+    j1: float
+    j2: float
+    j3: float
+    j4: float
+    j5: float
+    j6: float


### PR DESCRIPTION
This uses KCL's `show curpos`, which:

> Displays the position of the TCP relative to the current user frame of reference with an x, y, and z location in millimeters; w, p, and r orientation in degrees; and the current configuration string.

Probably not 100% robust, but initial testing shows it to work reasonably well.

For #12.
