### PR TITLE
add 'dominh set' and 'dominh info' to CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/bin/dominh
+++ b/bin/dominh
@@ -35,6 +35,7 @@ Available commands:
    write          Write to supported IO ports
    get            Retrieve the value of a scalar system variable
    set            Set the value of a scalar system variable
+   info           Print controller info
 
 See 'dominh <command> --help' for more information on a specific command.
 
@@ -74,6 +75,10 @@ if __name__ == '__main__':
     elif args['<command>'] == 'set':
         from dominh.tool import dominh_set
         dominh_set.main(argv=argv, skip_upload=skip_upload))
+
+    elif args['<command>'] == 'info':
+        from dominh.tool import dominh_info
+        dominh_info.main(argv=argv)
 
     else:
         sys.stderr.write(f"'{args['<command>']}' is not a dominh command.\n{__doc__}")

--- a/bin/dominh
+++ b/bin/dominh
@@ -34,6 +34,7 @@ Available commands:
    read           Read from supported IO ports
    write          Write to supported IO ports
    get            Retrieve the value of a scalar system variable
+   set            Set the value of a scalar system variable
 
 See 'dominh <command> --help' for more information on a specific command.
 
@@ -69,6 +70,10 @@ if __name__ == '__main__':
     elif args['<command>'] == 'get':
         from dominh.tool import dominh_get
         dominh_get.main(argv=argv, skip_upload=skip_upload)
+
+    elif args['<command>'] == 'set':
+        from dominh.tool import dominh_set
+        dominh_set.main(argv=argv, skip_upload=skip_upload))
 
     else:
         sys.stderr.write(f"'{args['<command>']}' is not a dominh command.\n{__doc__}")

--- a/src/dominh/__init__.py
+++ b/src/dominh/__init__.py
@@ -352,7 +352,7 @@ class ScalarVariable(Variable):
 
     @val.setter
     def val(self, val: t.Type[t.Union[bool, float, int, str]]) -> None:
-        if type(val) != self.typ:
+        if not isinstance(val, self.typ):
             raise ValueError(f"Cannot write {type(val)} to variable of type {self.typ}")
         # we explicitly convert to str here, as set_scalar_var(..) will always
         # send values as strings

--- a/src/dominh/comset.py
+++ b/src/dominh/comset.py
@@ -79,7 +79,7 @@ def comset(
         raise ValueError("Need either val or comment")
 
     if val:
-        real_flag = 1 if type(val) == float else -1
+        real_flag = 1 if isinstance(val, float) else -1
         params = {'sValue': val, 'sIndx': idx, 'sRealFlag': real_flag, 'sFc': fc}
 
     if comment:

--- a/src/dominh/registers.py
+++ b/src/dominh/registers.py
@@ -54,7 +54,7 @@ def set_strreg(conx: Connection, idx: int, val: str) -> None:
     :param val: The value to write to the register
     :type val: str
     """
-    assert type(val) == str
+    assert isinstance(val, str)
     comset_val(conx, ValueFuncCode.STRREG, idx, val=val)
 
 

--- a/src/dominh/tool/dominh_info.py
+++ b/src/dominh/tool/dominh_info.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020, G.A. vd. Hoorn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Retrieve basic info from controller.
+
+Usage: dominh [--no-upload] info [options] [--short] <host>
+
+Options:
+  -h --help     Show this screen.
+
+"""
+
+import sys
+
+from docopt import docopt
+from requests import exceptions
+
+import dominh
+
+
+def main(argv, skip_upload=False):
+    args = docopt(__doc__, argv=argv)
+    try:
+        c = dominh.connect(host=args['<host>'], skip_helper_upload=skip_upload)
+    except (exceptions.ConnectionError, OSError) as e:
+        sys.stderr.write(f"Error trying to connect to the controller: {e}\n")
+        return
+
+    if (not args['--short']):
+        print('\nController info:')
+        print(f'  Time                  : {c.current_time}')
+        print(f'  Series                : {c.series}')
+        print(f'  Application           : {c.application}')
+        print(f'  Software version      : {c.system_software_version}')
+        print(f'  $FNO                  : {c.variable("[*system*]$fno", typ=str).val}')
+
+        print('\nRobot info:')
+
+        num_groups = c.num_groups
+        print(f'  Number of groups      : {num_groups}')
+
+        for grp in [c.group(i + 1) for i in range(num_groups)]:
+            print(f'  Group {grp.id}:')
+            print(f'    ID                  : {grp.robot_id}')
+            print(f'    Model               : {grp.robot_model}')
+            print(f'    Current pose        : {grp.curpos}')
+
+        print(f'\nGeneral override        : {c.general_override}%')
+
+    try:
+        print('\nController status:')
+        print(f'  TP enabled            : {str(c.tp_enabled):5}')
+        print(f'  In AUTO               : {str(c.in_auto_mode):5}')
+        print(f'  In error              : {str(c.is_faulted):5}')
+        print(f'  E-stopped             : {str(c.is_e_stopped):5}')
+        print(f'  Remote mode           : {str(c.in_remote_mode):5}')
+        print(f'  Program running       : {str(c.is_program_running):5}')
+        print(f'  Program paused        : {str(c.is_program_paused):5}')
+    except dominh.exceptions.DominhException as e:
+        print(f"\nCouldn't access some IO: {e}")
+
+    numregs = ', '.join([str(c.numreg(i + 1).val) for i in range(5)])
+
+    if (not args['--short']):
+        print('\nOther info:')
+        print(f'\nFirst 5 numregs         : {numregs}')
+
+        try:
+            sopins = ', '.join([str(c.sopin(i + 1).val) for i in range(5)])
+            print(f'\nFirst 5 SOP inputs      : {sopins}')
+        except dominh.exceptions.DominhException as e:
+            print(f"\nCouldn't access some IO: {e}")
+
+        pld = c.group(1).payload(1)
+        pld_frame = f'({pld.payload_x}, {pld.payload_y}, {pld.payload_z})'
+        pld_inertia = f'{pld.payload_ix}, {pld.payload_iy}, {pld.payload_iz}'
+        pld_final = f'{pld.payload} Kg at {pld_frame} (inertia: {pld_inertia}'
+        print(
+            f'\nPayload 1 in group 1    : {pld_final})'
+        )
+
+        prgs = '; '.join([f"{nam}.{ext}" for nam, ext in c.list_programs()[:5]])
+        print(f'\nFirst five programs     : {prgs}')
+
+    errs = '\n  '.join(
+        [
+            f'{stamp} {lvl:7s} {msg:42}'
+            for _, stamp, msg, _, lvl, _ in c.list_errors()[:10]
+        ]
+    )
+    print(f'\nTen most recent Errors:\n  {errs}')

--- a/src/dominh/tool/dominh_set.py
+++ b/src/dominh/tool/dominh_set.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020, G.A. vd. Hoorn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# author: G.A. vd. Hoorn, pd
+
+
+"""
+Set value of a (system) variable.
+
+Usage: dominh [--no-upload] set [options] <host> <variable> <value>
+
+Options:
+  -h --help     Show this screen.
+
+"""
+
+import sys
+
+from docopt import docopt
+from requests import exceptions
+
+import dominh
+
+
+def main(argv, skip_upload=False):
+    args = docopt(__doc__, argv=argv)
+
+    varname = args['<variable>']
+
+    try:
+        c = dominh.connect(host=args['<host>'], skip_helper_upload=skip_upload)
+        c.variable(varname).val = args['<value>']
+
+    except (exceptions.ConnectionError, OSError) as e:
+        sys.stderr.write(f"Error trying to connect to the controller: {e}\n")
+    except dominh.DominhException as e:
+        sys.stderr.write(f"Error during write: {e}\n")

--- a/src/dominh/utils.py
+++ b/src/dominh/utils.py
@@ -19,7 +19,7 @@ import typing as t
 
 
 def format_sysvar(path: t.List[str]) -> str:
-    assert type(path) == list
+    assert isinstance(path, list)
     if not path:
         raise ValueError("Need at least one variable name")
     return ('$' + '.$'.join(path)).upper()


### PR DESCRIPTION
This extends the dominh CLI with 'set' and 'info' commands. 'set' may require controller to be in controlled start for some variables. 

```
Usage: dominh [--no-upload] set [options] <host> <variable> <value>
Usage: dominh [--no-upload] info [options] [--short] <host>
```

Examples
```
dominh info 10.0.0.200
dominh info --short 10.0.0.200
dominh set 10.0.0.200 $SCR.$MAXNUMTASKS 6 
```

Other Notes:
- You may need to escape/quote the variable names properly depending on your os shell environment.
- 'set' was just a slight modification to 'get', not sure if this is actually a sane way to implement this. It worked for all variables we needed and tested, using controller firmware version v9.30 and v9.40.
- 'info' is mostly copy-pasted from `examples/print_controller_info.py`. I added an optional `--short` flag. I also changed some of the terminal output to be fixed-width and padded, for better behaviour when chaining with other CLI commands like `watch`.
- There is an outstanding issue, using `info` during controlled start produces an exception. This should probably be fixed, or at least the exception should be handled and produce more useful output for the user if it is the expected behavior. I believe it is an issue which existed before this commit, maybe even in the karel code. I *think* that running `examples/print_controller_info.py` in controlled start will also produce the same exception, though I am unable to test this now as I don't have access to a FANUC.
